### PR TITLE
List API: Selector, filters, pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,38 @@ Few important things:
 * It comes with GitHub Actions support, [based on that article](https://hacksoft.io/github-actions-in-action-setting-up-django-and-postgres/)
 * It comes with [`whitenoise`](http://whitenoise.evans.io/en/stable/) setup.
 * It can be easily deployed to Heroku.
+* It comes with an example list API, that uses [`django-filter`](https://django-filter.readthedocs.io/en/stable/) for filtering & pagination from DRF.
+
+## Example List API
+
+List API is located at:
+
+<http://localhost:8000/api/users/>
+
+The API can be filtered:
+
+* <http://localhost:8000/api/users/?is_admin=True>
+* <http://localhost:8000/api/users/?id=1>
+* <http://localhost:8000/api/users/?email=radorado@hacksoft.io>
+
+Example data structure:
+
+```
+{
+    "limit": 1,
+    "offset": 0,
+    "count": 4,
+    "next": "http://localhost:8000/api/users/?limit=1&offset=1",
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "email": "radorado@hacksoft.io",
+            "is_admin": false
+        }
+    ]
+}
+```
 
 ## Helpful commands
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -44,6 +44,7 @@ THIRD_PARTY_APPS = [
     'rest_framework',
     'django_celery_results',
     'django_celery_beat',
+    'django_filters'
 ]
 
 INSTALLED_APPS = [
@@ -165,6 +166,9 @@ SIMPLE_JWT = {
 
 REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'styleguide_example.api.errors.custom_exception_handler',
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+    ),
 }
 
 from .celery import *  # noqa

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,5 @@ django-celery-results==1.2.1
 django-celery-beat==2.0.0
 
 whitenoise==5.1.0
+
+django-filter==2.4.0

--- a/styleguide_example/api/pagination.py
+++ b/styleguide_example/api/pagination.py
@@ -1,0 +1,47 @@
+from collections import OrderedDict
+
+from rest_framework.pagination import LimitOffsetPagination as _LimitOffsetPagination
+from rest_framework.response import Response
+
+
+def get_paginated_response(*, pagination_class, serializer_class, queryset, request, view):
+    paginator = pagination_class()
+
+    page = paginator.paginate_queryset(queryset, request, view=view)
+
+    if page is not None:
+        serializer = serializer_class(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    serializer = serializer_class(queryset, many=True)
+
+    return Response(data=serializer.data)
+
+
+class LimitOffsetPagination(_LimitOffsetPagination):
+    default_limit = 10
+    max_limit = 50
+
+    def get_paginated_data(self, data):
+        return OrderedDict([
+            ('limit', self.limit),
+            ('offset', self.offset),
+            ('count', self.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data)
+        ])
+
+    def get_paginated_response(self, data):
+        """
+        We redefine this method in order to return `limit` and `offset`.
+        This is used by the frontend to construct the pagination itself.
+        """
+        return Response(OrderedDict([
+            ('limit', self.limit),
+            ('offset', self.offset),
+            ('count', self.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data)
+        ]))

--- a/styleguide_example/api/tests/pagination/test_get_paginated_response.py
+++ b/styleguide_example/api/tests/pagination/test_get_paginated_response.py
@@ -1,0 +1,82 @@
+from collections import OrderedDict
+
+from django.test import TestCase
+
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+from rest_framework import serializers
+
+from styleguide_example.api.pagination import get_paginated_response, LimitOffsetPagination
+
+from styleguide_example.users.services import user_create
+from styleguide_example.users.models import BaseUser
+
+
+class ExampleListApi(APIView):
+    class Pagination(LimitOffsetPagination):
+        default_limit = 1
+
+    class OutputSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = BaseUser
+            fields = ('id', 'email')
+
+    def get(self, request):
+        queryset = BaseUser.objects.order_by('id')
+
+        response = get_paginated_response(
+            pagination_class=self.Pagination,
+            serializer_class=self.OutputSerializer,
+            queryset=queryset,
+            request=request,
+            view=self
+        )
+
+        return response
+
+
+class GetPaginatedResponseTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+        self.user1 = user_create(email='user1@hacksoft.io')
+        self.user2 = user_create(email='user2@hacksoft.io')
+
+    def test_response_is_paginated_correctly(self):
+        first_page_request = self.factory.get('/some/path')
+        first_page_response = ExampleListApi.as_view()(first_page_request)
+
+        expected_first_page_response = OrderedDict({
+            'limit': 1,
+            'offset': 0,
+            'count': BaseUser.objects.count(),
+            'next': 'http://testserver/some/path?limit=1&offset=1',
+            'previous': None,
+            'results': [
+                OrderedDict({
+                    'id': self.user1.id,
+                    'email': self.user1.email,
+                })
+            ]
+        })
+
+        self.assertEqual(expected_first_page_response, first_page_response.data)
+
+        next_page_request = self.factory.get('/some/path?limit=1&offset=1')
+        next_page_response = ExampleListApi.as_view()(next_page_request)
+
+        expected_next_page_response = OrderedDict({
+            'limit': 1,
+            'offset': 1,
+            'count': BaseUser.objects.count(),
+            'next': None,
+            'previous': 'http://testserver/some/path?limit=1',
+            'results': [
+                OrderedDict({
+                    'id': self.user2.id,
+                    'email': self.user2.email,
+                })
+            ]
+        })
+
+        self.assertEqual(expected_next_page_response, next_page_response.data)

--- a/styleguide_example/api/urls.py
+++ b/styleguide_example/api/urls.py
@@ -4,5 +4,6 @@ urlpatterns = [
     path(
         'auth/', include(('styleguide_example.authentication.urls', 'authentication'))
     ),
-    path('common/', include(('styleguide_example.common.urls', 'common')))
+    path('common/', include(('styleguide_example.common.urls', 'common'))),
+    path('users/', include(('styleguide_example.users.urls', 'users'))),
 ]

--- a/styleguide_example/users/apis.py
+++ b/styleguide_example/users/apis.py
@@ -1,0 +1,8 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+
+# TODO: When JWT is resolved, add authenticated version
+class UserListApi(APIView):
+    def get(self, request):
+        return Response()

--- a/styleguide_example/users/apis.py
+++ b/styleguide_example/users/apis.py
@@ -2,12 +2,19 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import serializers
 
+from styleguide_example.api.mixins import ApiErrorsMixin
+
 from styleguide_example.users.selectors import user_list
 from styleguide_example.users.models import BaseUser
 
 
 # TODO: When JWT is resolved, add authenticated version
-class UserListApi(APIView):
+class UserListApi(ApiErrorsMixin, APIView):
+    class FilterSerializer(serializers.Serializer):
+        id = serializers.IntegerField(required=False)
+        is_admin = serializers.BooleanField(required=False)
+        email = serializers.EmailField(required=False)
+
     class OutputSerializer(serializers.ModelSerializer):
         class Meta:
             model = BaseUser
@@ -18,7 +25,11 @@ class UserListApi(APIView):
             )
 
     def get(self, request):
-        users = user_list()
+        # Make sure the filters are valid, if passed
+        filters_serializer = self.FilterSerializer(data=request.query_params)
+        filters_serializer.is_valid(raise_exception=True)
+
+        users = user_list(filters=filters_serializer.validated_data)
 
         data = self.OutputSerializer(users, many=True).data
 

--- a/styleguide_example/users/apis.py
+++ b/styleguide_example/users/apis.py
@@ -1,8 +1,25 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework import serializers
+
+from styleguide_example.users.selectors import user_list
+from styleguide_example.users.models import BaseUser
 
 
 # TODO: When JWT is resolved, add authenticated version
 class UserListApi(APIView):
+    class OutputSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = BaseUser
+            fields = (
+                'id',
+                'email',
+                'is_admin'
+            )
+
     def get(self, request):
-        return Response()
+        users = user_list()
+
+        data = self.OutputSerializer(users, many=True).data
+
+        return Response(data)

--- a/styleguide_example/users/filters.py
+++ b/styleguide_example/users/filters.py
@@ -1,0 +1,9 @@
+import django_filters
+
+from styleguide_example.users.models import BaseUser
+
+
+class BaseUserFilter(django_filters.FilterSet):
+    class Meta:
+        model = BaseUser
+        fields = ('id', 'email', 'is_admin')

--- a/styleguide_example/users/selectors.py
+++ b/styleguide_example/users/selectors.py
@@ -1,5 +1,7 @@
 from styleguide_example.users.models import BaseUser
 
+from .filters import BaseUserFilter
+
 
 def user_get_login_data(*, user: BaseUser):
     return {
@@ -12,5 +14,9 @@ def user_get_login_data(*, user: BaseUser):
 
 
 # TODO: Add queryset return type
-def user_list():
-    return BaseUser.objects.all()
+def user_list(*, filters=None):
+    filters = filters or {}
+
+    qs = BaseUser.objects.all()
+
+    return BaseUserFilter(filters, qs).qs

--- a/styleguide_example/users/selectors.py
+++ b/styleguide_example/users/selectors.py
@@ -9,3 +9,8 @@ def user_get_login_data(*, user: BaseUser):
         'is_admin': user.is_admin,
         'is_superuser': user.is_superuser,
     }
+
+
+# TODO: Add queryset return type
+def user_list():
+    return BaseUser.objects.all()

--- a/styleguide_example/users/urls.py
+++ b/styleguide_example/users/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .apis import UserListApi
+
+
+urlpatterns = [
+    path('', UserListApi.as_view(), name='list')
+]


### PR DESCRIPTION
List API is located at:

http://localhost:8000/api/users/

The API can be filtered:

http://localhost:8000/api/users/?is_admin=True
http://localhost:8000/api/users/?id=1
http://localhost:8000/api/users/?email=radorado@hacksoft.io

Example data structure:

```
{
    "limit": 1,
    "offset": 0,
    "count": 4,
    "next": "http://localhost:8000/api/users/?limit=1&offset=1",
    "previous": null,
    "results": [
        {
            "id": 1,
            "email": "radorado@hacksoft.io",
            "is_admin": false
        }
    ]
}
```

TODO:

- [x] Update README with added django filters + example
- [x] Add tests